### PR TITLE
Fix saving/exporting of models

### DIFF
--- a/models/pggan_generator_model.py
+++ b/models/pggan_generator_model.py
@@ -272,7 +272,7 @@ class ConvBlock(nn.Module):
     if upsample and not fused_scale:
       self.upsample = ResolutionScalingLayer()
     else:
-      self.upsample = lambda x: x
+      self.upsample = nn.Identity()
 
     if upsample and fused_scale:
       self.weight = nn.Parameter(
@@ -295,7 +295,7 @@ class ConvBlock(nn.Module):
                               gain=wscale_gain)
 
     if activation_type == 'linear':
-      self.activate = (lambda x: x)
+      self.activate = nn.Identity()
     elif activation_type == 'lrelu':
       self.activate = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     elif activation_type == 'tanh':

--- a/models/stylegan_generator_model.py
+++ b/models/stylegan_generator_model.py
@@ -801,7 +801,7 @@ class DenseBlock(nn.Module):
                               gain=wscale_gain,
                               lr_multiplier=wscale_lr_multiplier)
     if activation_type == 'linear':
-      self.activate = (lambda x: x)
+      self.activate = nn.Identity()
     elif activation_type == 'lrelu':
       self.activate = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     else:


### PR DESCRIPTION
Saving/exporting models with `torch.save` relies on pickling the given network, which results in errors for the generator models in the code base as they use unpickable lambda functions when an identity operation needs to be used.

These changes replace the usage of lambda functions by their corresponding torch operations, enabling the saving of models.

The error can be simply reproduced for a given model using the following code:
```python
import torch
from models.stylegan_generator import StyleGANGenerator

model = StyleGANGenerator('stylegan_ffhq')
torch.save(model.model, 'model.pt')
```
for the StyleGAN model and
```python
import torch
from models.pggan_generator_model import PGGANGeneratorModel

model = PGGANGenerator('pggan_celebahq')
torch.save(model.model, 'model.pt')
```
for the PGGAN one.

Edit: the identity operation is a relatively new feature and has been merged in [this](https://github.com/pytorch/pytorch/pull/19249) PR.